### PR TITLE
SmartWB Firmware 2.2.3 - Voltage in API

### DIFF
--- a/modules/simpleevsewifis1/main.sh
+++ b/modules/simpleevsewifis1/main.sh
@@ -7,6 +7,9 @@ watt=$(echo $output | jq '.list[] | .actualPower')
 lla1=$(echo $output | jq '.list[] | .currentP1')
 lla2=$(echo $output | jq '.list[] | .currentP2')
 lla3=$(echo $output | jq '.list[] | .currentP3')
+llv1=$(echo $output | jq '.list[] | .voltageP1')
+llv2=$(echo $output | jq '.list[] | .voltageP2')
+llv3=$(echo $output | jq '.list[] | .voltageP3')
 llkwh=$(echo $output | jq '.list[] | .meterReading')
 evsewifiplugstatelp2=$(echo $output | jq '.list[] | .vehicleState') 
 watt=$(echo "scale=0;$watt * 1000 /1" |bc)
@@ -21,6 +24,15 @@ if [[ $lla2 =~ $rekwh ]] ; then
 fi
 if [[ $lla3 =~ $rekwh ]] ; then
 	echo $lla3 > /var/www/html/openWB/ramdisk/llas13
+fi
+if [[ $llv1 =~ $rekwh ]] ; then
+        echo $llv1 > /var/www/html/openWB/ramdisk/llvs11
+fi
+if [[ $llv2 =~ $rekwh ]] ; then
+        echo $llv2 > /var/www/html/openWB/ramdisk/llvs12
+fi
+if [[ $llv3 =~ $rekwh ]] ; then
+        echo $llv3 > /var/www/html/openWB/ramdisk/llvs13
 fi
 if [[ $llkwh =~ $rekwh ]] ; then
 	echo $llkwh > /var/www/html/openWB/ramdisk/llkwhs1


### PR DESCRIPTION
Firmware 2.2.3 has Voltage in API:

https://www.evse-wifi.de/2021/06/20/software-update-version-2-2-3/

```
{
  "type": "parameters",
  "list": [
    {
      "vehicleState": 1,
      "evseState": true,
      "maxCurrent": 16,
      "actualCurrent": 16,
      "actualPower": 0,
      "duration": 0,
      "alwaysActive": true,
      "lastActionUser": "",
      "lastActionUID": "",
      "energy": 0,
      "mileage": 0,
      "meterReading": 0.34,
      "currentP1": 0,
      "currentP2": 0,
      "currentP3": 0,
      "voltageP1": 227.4612,
      "voltageP2": 226.9189,
      "voltageP3": 225.791,
      "useMeter": true,
      "RFIDUID": ""
    }
  ]
}
```